### PR TITLE
Make the `Search all items` setting tool-tip readable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-	mavenLocal()
+//	mavenLocal()
 	maven {
 		url = 'https://repo.runelite.net'
 	}

--- a/src/main/java/com/weaponanimationreplacer/WeaponAnimationReplacerConfig.java
+++ b/src/main/java/com/weaponanimationreplacer/WeaponAnimationReplacerConfig.java
@@ -11,9 +11,9 @@ public interface WeaponAnimationReplacerConfig extends Config
 		keyName = "showUnequippableItems",
 		name = "Search all items",
 		description = "Include all items when searching for model swaps, which may include new items that runelite does not yet " +
-			"know are equippable, as well as items that are not equippable but do have player models. These items do" +
+			"know are equippable,<br/> as well as items that are not equippable but do have player models.<br/> These items do" +
 			"not have equip slot information, so you will have to right-click the item in the search interface and" +
-			"choose an equip slot. WARNING: This also includes items with no player model."
+			"choose an equip slot.<br/> WARNING: This also includes items with no player model."
 	)
 	default boolean showUnequippableItems()
 	{

--- a/src/test/java/com/weaponanimationreplacer/WeaponAnimationReplacerToolsPlugin.java
+++ b/src/test/java/com/weaponanimationreplacer/WeaponAnimationReplacerToolsPlugin.java
@@ -922,6 +922,7 @@ public class WeaponAnimationReplacerToolsPlugin extends Plugin
 			{
 
 				System.out.println(integerIntegerEntry.getKey() + " " + integerIntegerEntry.getValue());
+//				System.out.println("slot " + KitType.values()[integerIntegerEntry.getKey()] + " (" + integerIntegerEntry.getKey() + ") " + integerIntegerEntry.getValue());
 			}
 			System.out.println("reloading animations sets");
 			AnimationSet.loadAnimationSets();


### PR DESCRIPTION
During a random conversation, I was linked an image showing of the current tool-tip for the `Search all items` setting, which is frankly unreadable.

So I went ahead and added some crispy HTML to actually wrap the text around to a readable state

I pointed this PR to the 3.6.0 branch, if you want to create a `3.6.1` branch and swap it to that, that's perfectly fine :+1:

<details>
  <summary>before:</summary>

![VdBrHRe](https://github.com/geheur/weapon-animation-replacer/assets/41973452/f15a40b4-1522-4d76-8a2b-be7340a87587)

</details>

<details>
  <summary>after:</summary>

![image](https://github.com/geheur/weapon-animation-replacer/assets/41973452/44f74548-94c7-4880-a142-be6d8d138ae3)

</details>


![image](https://github.com/geheur/weapon-animation-replacer/assets/41973452/76fe0f36-bda7-45d0-9868-50c0bb682ee0)
